### PR TITLE
Add sketch name to download endpoint of compiler

### DIFF
--- a/ardublockly/sensebox_extensions.js
+++ b/ardublockly/sensebox_extensions.js
@@ -73,24 +73,25 @@ SenseboxExtension.init = function() {
     var request = ArdublocklyServer.createRequest();
     // The data received is JSON, so it needs to be converted into the right
     // format to be displayed in the page.
-    var onReady = function() {
+    var onReady = function () {
       if (request.readyState == 4) {
         if (request.status == 200) {
           var response = null;
           try {
             var openDownload = function () {
-                            response = JSON.parse(request.response);
-                            window.open('https://compiler.sensebox.de/download?id='+response.data.id+'&board='+window.BOARD, '_self');
-                          }
-                            Ardublockly.alertMessage(
-                            Ardublockly.getLocalStr('sketch_compiled'),
-                            Ardublockly.getLocalStr('copy_paste_mcu'),
-                            true, openDownload
-                          );
+              response = JSON.parse(request.response);
+              var filename = document.getElementById('sketch_name').value;
+              window.open('https://compiler.sensebox.de/download?id=' + response.data.id + '&board=' + window.BOARD + '&filename=' + filename, '_self');
+            }
+            Ardublockly.alertMessage(
+              Ardublockly.getLocalStr('sketch_compiled'),
+              Ardublockly.getLocalStr('copy_paste_mcu'),
+              true, openDownload
+            );
             /*response = JSON.parse(request.response);
             window.open('https://compiler.sensebox.de/download?id='+response.data.id+'&board='+window.BOARD, '_self');
             Ardublockly.MaterialToast(Ardublockly.getLocalStr('sketch_compiled'));*/
-          } catch(e) {
+          } catch (e) {
             throw e;
           }
         } else if (request.status == 500) {


### PR DESCRIPTION
Now it`s possible to set the filename in `download` endpoint of sensebox compiler
https://github.com/sensebox/sensebox-sketches/pull/9/commits/b8d4ed660f75dc452635d184edf825cd2adaf135

This PR adds the filename (sketch name) to the request.