### PR TITLE
add os detection

### DIFF
--- a/ardublockly/msg/de.js
+++ b/ardublockly/msg/de.js
@@ -74,7 +74,8 @@ Ardublockly.LOCALISED_TEXT = {
   copy_paste_mcu: "Kopiere die .BIN Datei auf deine senseBox MCU. <br> Wird die senseBox MCU im Explorer nicht angezeigt mache eine Doppelklick auf den Roten Reset Button.<br>" +
     "<img class='animated-gif' src=\"img/copy_to_mcu.gif\"> <br>" +
     "Benötigst du mehr Information und Hilfe schau ins <a href=\"https://sensebox.github.io/books-v2/blockly/de/\" target=\"_blank\">Blockly für senseBox Buch</a>",
-
+  copy_paste_mcu_mac: "Kopiere die .BIN Datei auf deine senseBox MCU. <br> Du verwendest MacOS als Betriebssystem, bitte kopiere deine Datei mit Hilfe: <ul><li><a href=\"https://sensebox.de/docs/senseBox_Sketch_Uploader_DE.zip\">Kopiertool<a/></li><li><a href=\"https://www.mucommander.com/\">MuCommander</a></li></ul><br>" +
+    "Das kopiere über den normalen Finder funktioniert leider nicht",
   /* Alerts */
   loadNewBlocksTitle: "Neue Blöcke laden?",
   loadNewBlocksBody: "Das Laden der neuen XML-Datei ersetzt die aktuellen Blöcke.<br>" +

--- a/ardublockly/msg/de.js
+++ b/ardublockly/msg/de.js
@@ -74,8 +74,7 @@ Ardublockly.LOCALISED_TEXT = {
   copy_paste_mcu: "Kopiere die .BIN Datei auf deine senseBox MCU. <br> Wird die senseBox MCU im Explorer nicht angezeigt mache eine Doppelklick auf den Roten Reset Button.<br>" +
     "<img class='animated-gif' src=\"img/copy_to_mcu.gif\"> <br>" +
     "Benötigst du mehr Information und Hilfe schau ins <a href=\"https://sensebox.github.io/books-v2/blockly/de/\" target=\"_blank\">Blockly für senseBox Buch</a>",
-  copy_paste_mcu_mac: "Kopiere die .BIN Datei auf deine senseBox MCU. <br> Du verwendest MacOS als Betriebssystem, bitte kopiere deine Datei mit Hilfe: <ul><li><a href=\"https://sensebox.de/docs/senseBox_Sketch_Uploader_DE.zip\">Kopiertool<a/></li><li><a href=\"https://www.mucommander.com/\">MuCommander</a></li></ul><br>" +
-    "Das kopiere über den normalen Finder funktioniert leider nicht",
+  copy_paste_mcu_mac: "Kopiere die .BIN Datei auf deine senseBox MCU. <br> Du verwendest MacOS als Betriebssystem. Das Kopieren der .BIN Dateien über den Finder funktioniert leider nicht. <br> Benutze bitte eines der folgenden Tools: <ul><li style=\"list-style: square;\"><a href=\"https://sensebox.de/docs/senseBox_Sketch_Uploader_DE.zip\">senseBox Kopiertool<a/></li><li style=\"list-style: square;\"><a href=\"https://www.mucommander.com/\">MuCommander</a></li></ul><br>",
   /* Alerts */
   loadNewBlocksTitle: "Neue Blöcke laden?",
   loadNewBlocksBody: "Das Laden der neuen XML-Datei ersetzt die aktuellen Blöcke.<br>" +

--- a/ardublockly/msg/en.js
+++ b/ardublockly/msg/en.js
@@ -74,8 +74,7 @@ Ardublockly.LOCALISED_TEXT = {
   copy_paste_mcu: "Copy the .BIN Datei to your senseBox MCU. <br> If your senseBox MCU is not shown do a fast double push to the reset button.<br>" +
     "<img class='animated-gif'src=\"img/copy_to_mcu.gif\"> <br>" +
     "You need more help? See here <a href=\"https://sensebox.github.io/books-v2/blockly/en/\" target=\"_blank\">Blockly for senseBox Book</a>",
-  copy_paste_mcu_mac: "Copy the .BIN File to your senseBox MCU. <br> You are using MacOS as your operating system, please copy the file using  <ul><li style=\"list-style: square;\"><a href=\"https://sensebox.de/docs/senseBox_Sketch_Uploader_DE.zip\">Copy Tool<a/></li><li style=\"list-style: square;\"><a href=\"https://www.mucommander.com/\">MuCommander</a></li></ul><br>" +
-    "Copying the file with the normal Finder won't work",
+  copy_paste_mcu_mac: "Copy the .BIN File to your senseBox MCU. <br> You are using MacOS as your operating system. Copying the file with the normal Finder won't work, please copy the file using one of the following tools:  <ul><li style=\"list-style: square;\"><a href=\"https://sensebox.de/docs/senseBox_Sketch_Uploader_DE.zip\">Copy Tool<a/></li><li style=\"list-style: square;\"><a href=\"https://www.mucommander.com/\">MuCommander</a></li></ul><br>",
   /* Alerts */
   loadNewBlocksTitle: "Load new blocks?",
   loadNewBlocksBody: "Loading a new XML file will replace the current blocks from the workspace.<br>" +

--- a/ardublockly/msg/en.js
+++ b/ardublockly/msg/en.js
@@ -74,6 +74,8 @@ Ardublockly.LOCALISED_TEXT = {
   copy_paste_mcu: "Copy the .BIN Datei to your senseBox MCU. <br> If your senseBox MCU is not shown do a fast double push to the reset button.<br>" +
     "<img class='animated-gif'src=\"img/copy_to_mcu.gif\"> <br>" +
     "You need more help? See here <a href=\"https://sensebox.github.io/books-v2/blockly/en/\" target=\"_blank\">Blockly for senseBox Book</a>",
+  copy_paste_mcu_mac: "Copy the .BIN File to your senseBox MCU. <br> You are using MacOS as your operating system, please copy the file using  <ul><li style=\"list-style: square;\"><a href=\"https://sensebox.de/docs/senseBox_Sketch_Uploader_DE.zip\">Copy Tool<a/></li><li style=\"list-style: square;\"><a href=\"https://www.mucommander.com/\">MuCommander</a></li></ul><br>" +
+    "Copying the file with the normal Finder won't work",
   /* Alerts */
   loadNewBlocksTitle: "Load new blocks?",
   loadNewBlocksBody: "Loading a new XML file will replace the current blocks from the workspace.<br>" +

--- a/ardublockly/sensebox_extensions.js
+++ b/ardublockly/sensebox_extensions.js
@@ -113,12 +113,27 @@ SenseboxExtension.init = function () {
                 window.open(compilerOnline + '/download?id=' + response.data.id + '&board=' + window.BOARD + '&filename=' + filename, '_self');
               }
               var no_thanks = sessionStorage.getItem('no_thanks');
+              var Name = "Not known";
+              if (navigator.appVersion.indexOf("Win") != -1) Name =
+                "Windows OS";
+              if (navigator.appVersion.indexOf("Mac") != -1) Name =
+                "MacOS";
+              if (navigator.appVersion.indexOf("X11") != -1) Name =
+                "UNIX OS";
+              if (navigator.appVersion.indexOf("Linux") != -1) Name =
+                "Linux OS";
+              console.log(navigator.platform);
               // If no cookie with our chosen name (e.g. no_thanks)...
               if (no_thanks == "false") {
-
-                window.setTimeout(Ardublockly.alertMessage(
-                  Ardublockly.getLocalStr('sketch_compiled'),
-                  Ardublockly.getLocalStr('copy_paste_mcu')), 1000);
+                if (navigator.platform == "MacIntel") {
+                  window.setTimeout(Ardublockly.alertMessage(
+                    Ardublockly.getLocalStr('sketch_compiled'),
+                    Ardublockly.getLocalStr('copy_paste_mcu_mac')), 1000);
+                }
+                else
+                  window.setTimeout(Ardublockly.alertMessage(
+                    Ardublockly.getLocalStr('sketch_compiled'),
+                    Ardublockly.getLocalStr('copy_paste_mcu')), 1000);
               }
               window.setTimeout(download, 1000);
 


### PR DESCRIPTION
This PR will add OS detection to provide correct information to copy the .Bin file to the senseBox MCU. 

- detection for Linux based systems is missing, but the copy process is the same like in windows.

fixes #172 

@bgunt @synolus-david could you please test this as you are using different OS.